### PR TITLE
Send JSON instead of formdata on direct upload

### DIFF
--- a/addon/-private/uploader.js
+++ b/addon/-private/uploader.js
@@ -1,12 +1,12 @@
 import EmberObject from '@ember/object';
-import { inject } from '@ember/service';
+import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { run } from '@ember/runloop';
 import { tryInvoke } from '@ember/utils';
 import { get, setProperties } from '@ember/object';
 
 var Uploader = EmberObject.extend({
-  ajax: inject(),
+  ajax: service(),
 
   upload(blob, url, resolve, reject) {
     get(this, '_uploadTask').perform(blob, url, resolve, reject);

--- a/addon/-private/uploader.js
+++ b/addon/-private/uploader.js
@@ -25,14 +25,15 @@ var Uploader = EmberObject.extend({
   _directUpload(blob, url) {
     return this.get('ajax').request(url, {
       method: 'POST',
-      data: {
+      contentType: 'application/json; charset=utf-8',
+      data: JSON.stringify({
         blob: {
           filename: blob.get('name'),
           content_type: blob.get('type'),
           byte_size: blob.get('size'),
           checksum: blob.get('checksum')
         }
-      }
+      })
     }).then( (response) => {
       setProperties(blob, {
         id: response.id,

--- a/tests/dummy/app/components/file-upload.js
+++ b/tests/dummy/app/components/file-upload.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { inject } from '@ember/service';
+import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import { debug } from '@ember/debug';
@@ -9,7 +9,7 @@ import layout from '../templates/components/file-upload';
 export default Component.extend({
   layout,
 
-  activeStorage: inject(),
+  activeStorage: service(),
 
   actions: {
     upload(event) {


### PR DESCRIPTION
On direct upload, data was being sent as formdata:

![screen shot 2018-02-27 at 15 01 21](https://user-images.githubusercontent.com/2955556/36732822-21d65f2e-1bcf-11e8-80a0-3da2b4424d76.png)

I think it's better to send it as a JSON string, so that both request and response "speak the same language" 😉 

![screen shot 2018-02-27 at 14 45 04](https://user-images.githubusercontent.com/2955556/36732459-2a383f4e-1bce-11e8-9326-cb14d56e0037.png)
