### PR TITLE
Mirage instance initializer

### DIFF
--- a/tests/dummy/app/instance-initializers/mirage-workaround.js
+++ b/tests/dummy/app/instance-initializers/mirage-workaround.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+import Service from '@ember/service';
+
+//
+// This is a workaround for https://github.com/samselikoff/ember-cli-mirage/issues/1257
+//
+export function initialize(application) {
+
+  if (Ember.testing) {
+    if (!window.server) {
+      application.resolveRegistration('initializer:ember-cli-mirage').initialize();
+    }
+
+    application.register('service:mirage-workaround', Service.extend({
+      willDestroy() {
+        window.server.shutdown();
+        window.server = null;
+        this._super(...arguments);
+      }
+    }));
+    application.lookup('service:mirage-workaround');
+  }
+}
+
+export default {
+  name: 'mirage-workaround',
+  initialize
+};


### PR DESCRIPTION
Due to https://github.com/samselikoff/ember-cli-mirage/issues/1257,
we will need this workaround until Mirage updates to fit the new test framework.

This will fix tests in #10