### PR TITLE
permits to pass custom directUpload headers

### DIFF
--- a/addon/-private/uploader.js
+++ b/addon/-private/uploader.js
@@ -27,6 +27,7 @@ var Uploader = EmberObject.extend({
   _directUpload(blob, url) {
     return get(this, 'ajax').request(url, {
       method: 'POST',
+      headers: get(this, 'headers'),
       contentType: 'application/json; charset=utf-8',
       data: JSON.stringify({
         blob: {

--- a/addon/services/active-storage.js
+++ b/addon/services/active-storage.js
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import { getOwner } from '@ember/application';
 import { Promise as EmberPromise } from 'rsvp';
+import { get } from '@ember/object';
 
 import Uploader from 'ember-active-storage/-private/uploader';
 import Blob from 'ember-active-storage/model/blob';
@@ -10,7 +11,9 @@ export default Service.extend({
 
   upload(file, url, mixin) {
     const uploader = Uploader.extend(Mixin.create(mixin)).create(
-      getOwner(this).ownerInjection(),
+      getOwner(this).ownerInjection(), {
+        headers: get(this, 'headers')
+      }
     );
 
     return new EmberPromise((resolve, reject) => {


### PR DESCRIPTION
This fix allows the caller to extend the service and use custom headers

e.g. 

```javascript
import ActiveStorage from 'ember-active-storage/services/active-storage';
import { inject as service } from '@ember/service';
import { computed } from '@ember/object';

export default ActiveStorage.extend({
  session: service(),
  
  headers: computed('session.isAuthenticated', function() {
    var headers = {};
    this.get('session').authorize('authorizer:application', (name, value) => {
      headers[name] = value;
    });
    return headers;
  })

});
```