### PR TITLE
Prevent JSON parse error

### DIFF
--- a/addon/-private/uploader.js
+++ b/addon/-private/uploader.js
@@ -54,6 +54,7 @@ var Uploader = EmberObject.extend({
       method: 'PUT',
       headers: get(blob, 'directUploadData.headers'),
       processData: false,
+      dataType: 'text',
       contentType: get(blob, 'type'),
       data: get(blob, 'file'),
       xhr: () => {


### PR DESCRIPTION
Some storage services (Google Cloud Storage in my case) might return an empty string as the response of blob upload. I was getting this warning and error:

![screen shot 2018-03-12 at 18 05 36](https://user-images.githubusercontent.com/2955556/37302364-96710850-262b-11e8-8b99-f315aac80c1b.png)

That was happening because jQuery's [ajax method](http://api.jquery.com/jquery.ajax/) was trying to parse the received empty string as JSON. In order to avoid that, I set `dataType` as `text` so that no parse is attempted.