### PR TITLE
uploadResponse utility function for tests

### DIFF
--- a/addon/utils/tests.js
+++ b/addon/utils/tests.js
@@ -1,0 +1,34 @@
+function uploadResponse(requestBody, options = {}) {
+  const id = options.id || 123;
+  const key = options.key || 'cwUyfscVbcMNdo26Fkn9uHrW';
+  const signedId = options.signedId || 'eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d4c77635d82e4b007598f79bc3f785854eac27b9';
+  const directUploadURL = options.directUploadURL || '/api/attachments/direct-upload';
+
+  const blob = JSON.parse(requestBody).blob;
+
+  const headers = {
+    'Content-Type': 'application/json; charset=utf-8'
+  };
+
+  const body = {
+    id: id,
+    key: key,
+    filename: blob.filename,
+    content_type: blob.content_type,
+    metadata: {},
+    byte_size: blob.byte_size,
+    checksum: blob.checksum,
+    created_at: new Date().toISOString(),
+    signed_id: signedId,
+    direct_upload: {
+      url: directUploadURL,
+      headers: {
+        'Content-Type': blob.content_type
+      }
+    }
+  };
+
+  return { headers, body };
+}
+
+export { uploadResponse };

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,31 +1,14 @@
 import Response from 'ember-cli-mirage/response';
+import { uploadResponse } from 'ember-active-storage/utils/tests';
 
 export default function() {
   this.namespace = '/api';
 
   this.post('/attachments/upload', (_, request) => {
-    const blob = JSON.parse(request.requestBody).blob;
-    const respHeaders = {
-      'Content-Type': 'application/json; charset=utf-8'
-    };
-    const respBody = {
-      id: 123,
-      key: 'cwUyfscVbcMNdo26Fkn9uHrW',
-      filename: blob.filename,
-      content_type: blob.content_type,
-      metadata: {},
-      byte_size: blob.byte_size,
-      checksum: blob.checksum,
-      created_at: new Date().toISOString(),
-      signed_id: 'eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d4c77635d82e4b007598f79bc3f785854eac27b9',
-      direct_upload: {
-        url: '/api/attachments/direct-upload',
-        headers: {
-          'Content-Type': blob.content_type
-        }
-      }
-    };
-    return new Response(200, respHeaders, respBody);
+    const response = uploadResponse(request.requestBody, {
+      directUploadURL: '/api/attachments/direct-upload'
+    });
+    return new Response(200, response.headers, response.body);
   });
 
   this.put('/attachments/direct-upload', () => {


### PR DESCRIPTION
The `uploadResponse()` function is a test utility that allows to stub the response of your Rails app's ActiveStorage-based upload endpoint. It can be used in your Mirage route handler; however, it doesn't rely on any Mirage object, so we don't need to add Mirage as a dependency of `ember-active-storage`.