### PR TITLE
Remove dependence on jQuery

### DIFF
--- a/addon/-private/request.js
+++ b/addon/-private/request.js
@@ -1,0 +1,36 @@
+import { isPresent } from '@ember/utils';
+import { Promise } from 'rsvp';
+
+export default function(url, options) {
+  return new Promise((resolve, reject) => {
+    let xhr = options.xhr ? options.xhr() : new XMLHttpRequest();
+
+    xhr.open(options.method || 'GET', url);
+
+    if (options.headers) {
+      Object.keys(options.headers).forEach(key => {
+        xhr.setRequestHeader(key, options.headers[key]);
+      });
+    }
+    if (options.contentType) {
+      xhr.setRequestHeader('Content-Type', options.contentType);
+    }
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        let response;
+        if (options.dataType === 'text') {
+          response = xhr.responseText;
+        } else if (isPresent(xhr.responseText)) {
+          response = JSON.parse(xhr.responseText);
+        }
+        resolve(response);
+      } else {
+        reject(xhr.statusText);
+      }
+    };
+    xhr.onerror = () => reject(xhr.statusText);
+
+    xhr.send(options.data);
+  });
+}

--- a/addon/-private/uploader.js
+++ b/addon/-private/uploader.js
@@ -1,11 +1,11 @@
 import EmberObject from '@ember/object';
-import { inject as service } from '@ember/service';
 import { run } from '@ember/runloop';
 import { tryInvoke } from '@ember/utils';
 import { get, setProperties } from '@ember/object';
 
+import request from 'ember-active-storage/-private/request';
+
 var Uploader = EmberObject.extend({
-  ajax: service(),
 
   upload(blob, url, resolve, reject) {
     this._uploadTask(blob, url)
@@ -25,7 +25,7 @@ var Uploader = EmberObject.extend({
   },
 
   _directUpload(blob, url) {
-    return get(this, 'ajax').request(url, {
+    return request(url, {
       method: 'POST',
       headers: get(this, 'headers'),
       contentType: 'application/json; charset=utf-8',
@@ -50,15 +50,13 @@ var Uploader = EmberObject.extend({
   },
 
   _blobUpload(blob) {
-    return get(this, 'ajax').request(get(blob, 'directUploadData.url'), {
+    return request(get(blob, 'directUploadData.url'), {
       method: 'PUT',
       headers: get(blob, 'directUploadData.headers'),
-      processData: false,
       dataType: 'text',
-      contentType: false,
       data: blob.slice(),
       xhr: () => {
-        var xhr = new window.XMLHttpRequest();
+        var xhr = new XMLHttpRequest();
         xhr.upload.addEventListener('progress', (event) => this._uploadRequestDidProgress(event));
         return xhr;
       },

--- a/package.json
+++ b/package.json
@@ -32,10 +32,8 @@
     "spark-md5": "^3.0.0"
   },
   "devDependencies": {
-    "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
-    "ember-ajax": "^3.1.0",
     "ember-cli": "~3.4.3",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-eslint": "^4.2.3",

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,3 +1,3 @@
 {
-  "jquery-integration": true
+  "jquery-integration": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,16 +591,6 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@ember/jquery@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@ember/jquery/-/jquery-0.5.2.tgz#fe312c03ada0022fa092d23f7cd7e2eb0374b53a"
-  integrity sha1-/jEsA62gAi+gktI/fNfi6wN0tTo=
-  dependencies:
-    broccoli-funnel "^2.0.1"
-    ember-cli-babel "^6.6.0"
-    jquery "^3.3.1"
-    resolve "^1.7.1"
-
 "@ember/optional-features@^0.6.3":
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.6.4.tgz#8199f853c1781234fcb1f05090cddd0b822bff69"
@@ -2914,14 +2904,6 @@ electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.92:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.92.tgz#9027b5abaea400045edd652c0e4838675c814399"
   integrity sha512-En051LMzMl3/asMWGZEtU808HOoVWIpmmZx1Ep8N+TT9e7z/X8RcLeBU2kLSNLGQ+5SuKELzMx+MVuTBXk6Q9w==
 
-ember-ajax@^3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/ember-ajax/-/ember-ajax-3.1.3.tgz#f51b8e3e36765575a2698c8660e377d4d6371642"
-  integrity sha512-C+BmWxXECGWuv7T17OHSQySpVuoCalmxI/NLUr+3eSlBeCD0xwI3mRRL1CbmAWXdyNwzK3je+lFCSuMaJu2miA==
-  dependencies:
-    ember-cli-babel "^6.16.0"
-    najax "^1.0.3"
-
 ember-assign-polyfill@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.4.0.tgz#acb00466f7d674b3e6b030acfe255b3b1f6472e1"
@@ -5041,11 +5023,6 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jquery-deferred@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
-  integrity sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=
-
 jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
@@ -5981,15 +5958,6 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-najax@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/najax/-/najax-1.0.4.tgz#63fd8dbf15d18f24dc895b3a16fec66c136b8084"
-  integrity sha512-wsSacA+RkgY1wxRxXCT3tdqzmamEv9PLeoV/ub9SlLf2RngbPMSqc3A7H35XJDfURC0twMmZsnPdsYPkuuFSVg==
-  dependencies:
-    jquery-deferred "^0.3.0"
-    lodash.defaultsdeep "^4.6.0"
-    qs "^6.2.0"
-
 nan@^2.9.2:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.0.tgz#9d443fdb5e13a20770cc5e602eee59760a685885"
@@ -6616,7 +6584,7 @@ qs@6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-qs@^6.2.0, qs@^6.4.0:
+qs@^6.4.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
   integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
@@ -6952,7 +6920,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.3, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.7.1, resolve@^1.8.1:
+resolve@^1.1.3, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
   integrity sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==


### PR DESCRIPTION
Resolves #21 

I tried to change as little of the uploader code as possible and just implement as much direct use of `XMLHttpRequest` as needed to achieve the same functionality that the addon was previously using ember-ajax for. This addon now does not require jQuery and will work regardless of the consuming application's data loading strategy. I've been running this branch of the addon in a production app for two weeks now with no issues.

I didn't add any tests specifically around the new request code as there are existing tests for things such as ensuring the headers get passed to the server that indirectly test that the request implementation is working (and I made sure all of those tests passed as I implemented this request function).