### PR TITLE
Fix "File is undefined" error in Fastboot

### DIFF
--- a/addon/utils/file-checksum.js
+++ b/addon/utils/file-checksum.js
@@ -1,8 +1,6 @@
 import EmberObject from '@ember/object';
 import { Promise as EmberPromise } from 'rsvp';
 
-const fileSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice
-
 export default EmberObject.extend({
   init() {
     this._super(...arguments);
@@ -36,6 +34,8 @@ export default EmberObject.extend({
   },
 
   readNextChunk() {
+    let fileSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice
+
     if (this.chunkIndex < this.chunkCount) {
       const start = this.chunkIndex * this.chunkSize;
       const end = Math.min(start + this.chunkSize, this.file.size);

--- a/addon/utils/file-checksum.js
+++ b/addon/utils/file-checksum.js
@@ -5,9 +5,10 @@ export default EmberObject.extend({
   init() {
     this._super(...arguments);
 
-    this.chunkSize = 2097152; // 2MB
+    this.chunkSize  = 2097152; // 2MB
     this.chunkCount = Math.ceil(this.file.size / this.chunkSize);
     this.chunkIndex = 0;
+    this.fileSlice  = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice;
   },
 
   createMD5() {
@@ -34,12 +35,10 @@ export default EmberObject.extend({
   },
 
   readNextChunk() {
-    let fileSlice = File.prototype.slice || File.prototype.mozSlice || File.prototype.webkitSlice
-
     if (this.chunkIndex < this.chunkCount) {
       const start = this.chunkIndex * this.chunkSize;
       const end = Math.min(start + this.chunkSize, this.file.size);
-      const bytes = fileSlice.call(this.file, start, end);
+      const bytes = this.fileSlice.call(this.file, start, end);
       this.fileReader.readAsArrayBuffer(bytes);
       this.chunkIndex++;
       return true;


### PR DESCRIPTION
Fastboot was throwing errors on pages where this service was used saying that File was undefined. I moved the assignment into the function where it's used and that resolved the issue.