### PR TITLE
Change onreadystatechange to onloadstart event for XHRCreated event

### DIFF
--- a/addon/-private/request.js
+++ b/addon/-private/request.js
@@ -15,10 +15,8 @@ export default function (xhr, url, options) {
       xhr.setRequestHeader('Content-Type', options.contentType);
     }
 
-    xhr.onreadystatechange = () => {
-      if (xhr.readyState === 1) {
-        xhr.dispatchEvent(new CustomEvent('XHRCreated', { detail: xhr }));
-      }
+    xhr.onloadstart = () => {
+      xhr.dispatchEvent(new CustomEvent('XHRCreated', { detail: xhr }));
     };
 
     xhr.onload = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algonauti/ember-active-storage",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Power your ember.js application with activestorage",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
`onreadystatechange` function doesn't work on real time and this behavior prevents us to use `XHRCreated` event. It doesn't even throw an event when `readyState === 1`. Flushes all state changes when the load end. This is not useful for us.

Instead, I've changed to `onloadstart` event. This ensures the throw a `XHRCreated` event.

That way, we can finally manage the abort xhr upload process.

Thanks.
@safeforge @algodave 