### PR TITLE
Replace onXHRCreated with onXHROpened

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export default class UploadComponent extends Component {
 }
 ```
 
-If you need the actual `XHR object` in your app, you can use the `onXHRCreated` event. It returns the `XHR object` reference. For example:
+If you need the actual `XHR object` in your app, you can use the `onXHROpened` event. It returns the `XHR object` reference. For example:
 
 ```javascript
 import Component from '@glimmer/component';
@@ -136,7 +136,7 @@ export default class UploadComponent extends Component {
             onProgress: (progress) => {
               this.uploadProgress = progress;
             },
-            onXHRCreated: (xhr) => {
+            onXHROpened: (xhr) => {
               xhr.abort(); // You can abort the upload process here
             },
           })

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ export default class UploadComponent extends Component {
 
   @tracked
   uploadProgress = 0;
+  
+  @tracked
+  xhrs = [];
 
   @action
   upload(event) {
@@ -137,7 +140,7 @@ export default class UploadComponent extends Component {
               this.uploadProgress = progress;
             },
             onXHROpened: (xhr) => {
-              xhr.abort(); // You can abort the upload process here
+              this.xhrs.push(xhr);  // so you can loop over this.xhrs and invoke abort()
             },
           })
           .then((blob) => {

--- a/addon/-private/request.js
+++ b/addon/-private/request.js
@@ -15,11 +15,7 @@ export default function (xhr, url, options) {
       xhr.setRequestHeader('Content-Type', options.contentType);
     }
 
-    xhr.onreadystatechange = () => {
-      if (xhr.readyState === 1) {
-        xhr.dispatchEvent(new CustomEvent('XHRCreated', { detail: xhr }));
-      }
-    };
+    xhr.dispatchEvent(new CustomEvent('XHROpened', { detail: xhr }));
 
     xhr.onload = () => {
       if (xhr.status >= 200 && xhr.status < 300) {

--- a/addon/-private/uploader.js
+++ b/addon/-private/uploader.js
@@ -78,8 +78,8 @@ export default class Uploader {
   }
 
   _addCreatedListener(xhr) {
-    xhr.addEventListener('XHRCreated', ({ detail }) => {
-      this.events['onXHRCreated']?.(detail);
+    xhr.addEventListener('XHROpened', ({ detail }) => {
+      this.events['onXHROpened']?.(detail);
     });
   }
 

--- a/tests/dummy/app/components/file-upload.js
+++ b/tests/dummy/app/components/file-upload.js
@@ -29,7 +29,7 @@ export default class FileUploadComponent extends Component {
           onProgress: (progress) => {
             progressBarFill.style = `width: ${progress}%`;
           },
-          onXHRCreated: (xhr) => {
+          onXHROpened: (xhr) => {
             debug(`XHR created ${xhr}`);
           },
         })


### PR DESCRIPTION
We were having trouble with `onXHRCreated` because it was fired within an `xhr.onreadystatechange` callback, which was invoked too late to be useful.

So I thought: let's let callers get a reference of XHR objects right after `open()` method has been invoked, and let's see how `xhr.abort()` behaves. Well, I was able to cancel upload requests successfully, either when they're in the first stage (direct upload request), or when they're in the second stage (uploading file to storage service)