### PR TITLE
Add metadata to blob payload

### DIFF
--- a/addon/-private/uploader.js
+++ b/addon/-private/uploader.js
@@ -4,8 +4,9 @@ import { run } from '@ember/runloop';
 import { setProperties } from '@ember/object';
 
 export default class Uploader {
-  constructor({ headers, ...events }) {
+  constructor({ headers, metadata, ...events }) {
     this.headers = headers;
+    this.metadata = metadata;
     this.events = events;
   }
 
@@ -37,6 +38,7 @@ export default class Uploader {
           content_type: blob.type,
           byte_size: blob.size,
           checksum: blob.checksum,
+          metadata: this.metadata,
         },
       }),
     });

--- a/addon/services/active-storage.js
+++ b/addon/services/active-storage.js
@@ -15,19 +15,19 @@ export default class ActiveStorageService extends Service {
     return config['ember-active-storage'] || {};
   }
 
-  upload(file, urlOrCallbacks, callbacks = {}, metadata = {}) {
+  upload(file, urlOrOptions, options = {}) {
     let url;
 
-    if (isPresent(urlOrCallbacks)) {
-      if (typeOf(urlOrCallbacks) == 'string') {
-        url = urlOrCallbacks;
-      } else if (typeOf(urlOrCallbacks) == 'object') {
+    if (isPresent(urlOrOptions)) {
+      if (typeOf(urlOrOptions) == 'string') {
+        url = urlOrOptions;
+      } else if (typeOf(urlOrOptions) == 'object') {
         assert(
           "If not explicitly passed, URL must be set on ENV['ember-active-storage'] = { url: '...' }",
           isPresent(this._config['url'])
         );
 
-        callbacks = urlOrCallbacks;
+        options = urlOrOptions;
         url = this._config['url'];
       }
     } else {
@@ -38,6 +38,8 @@ export default class ActiveStorageService extends Service {
 
       url = this._config['url'];
     }
+
+    let { metadata, ...callbacks } = options;
 
     const uploader = new Uploader({
       headers: this.headers,

--- a/addon/services/active-storage.js
+++ b/addon/services/active-storage.js
@@ -15,7 +15,7 @@ export default class ActiveStorageService extends Service {
     return config['ember-active-storage'] || {};
   }
 
-  upload(file, urlOrCallbacks, callbacks = {}) {
+  upload(file, urlOrCallbacks, callbacks = {}, metadata = {}) {
     let url;
 
     if (isPresent(urlOrCallbacks)) {
@@ -39,7 +39,11 @@ export default class ActiveStorageService extends Service {
       url = this._config['url'];
     }
 
-    const uploader = new Uploader({ headers: this.headers, ...callbacks });
+    const uploader = new Uploader({
+      headers: this.headers,
+      metadata: metadata,
+      ...callbacks
+    });
 
     return new EmberPromise((resolve, reject) => {
       Blob.build(file).then((blob) => {


### PR DESCRIPTION
ActiveStorage supports metadata for direct uploads. That is a nice way to provide extra information to the rails app.
Here is a first approach how to implement it in the addon. If you like the idea we need to figure out how we deal with the
`upload(file, urlOrCallbacks, callbacks = {}, metadata = {})` parameter shifting.

Let me know what you think.